### PR TITLE
Bug Fixes in DHOLEmbedding/DHOLTCC

### DIFF
--- a/embedding-app/src/main/scala/leo/modules/EmbeddingApp.scala
+++ b/embedding-app/src/main/scala/leo/modules/EmbeddingApp.scala
@@ -2,7 +2,7 @@ package leo.modules
 
 import leo.datastructures.TPTP
 import leo.datastructures.TPTP.{AnnotatedFormula, Problem}
-import leo.modules.embeddings.{Embedding, EmbeddingException, EmbeddingN, Library, MalformedLogicSpecificationException, UnsupportedFragmentException, getLogicFromSpec, getLogicSpecFromProblem}
+import leo.modules.embeddings.{Embedding, EmbeddingException, EmbeddingN, Library, MalformedLogicSpecificationException, UnsupportedFragmentException, TypeErrorException, getLogicFromSpec, getLogicSpecFromProblem}
 import leo.modules.input.TPTPParser
 
 import java.io.{File, FileNotFoundException, PrintWriter}
@@ -127,6 +127,8 @@ object EmbeddingApp {
           error = Some("InputError", s"File cannot be found or is not readable/writable: ${e.getMessage}")
         case e: TPTPParser.TPTPParseException =>
           error = Some("SyntaxError", s"Input file could not be parsed, parse error at ${e.line}:${e.offset}: ${e.getMessage}")
+        case e: TypeErrorException =>
+          error = Some("TypeError", s"Unification process during type inference of equality failed. Unable to unify ${e.left.pretty} and ${e.right.pretty}")
         case e: Throwable =>
           error = Some("Error", s"Unexpected error: ${e.getMessage}. This is considered an implementation error, please report this!")
           System.err.println(s"Exception: ${e.toString}")

--- a/embedding-runtime/src/main/scala/leo/modules/embeddings/DHOLEmbedding.scala
+++ b/embedding-runtime/src/main/scala/leo/modules/embeddings/DHOLEmbedding.scala
@@ -6,7 +6,7 @@ import leo.datastructures.TPTP.THF.FunctionTerm
 
 import scala.annotation.tailrec
 
-/** @author Colin Rothgang, Daniel Renalter */
+/** @author Colin Rothgang, Rhea Ranalter */
 object DHOLEmbedding extends Embedding {
   import DHOLEmbeddingUtils._
   var constants : List[(String, TPTP.THF.Type)] = Nil

--- a/embedding-runtime/src/main/scala/leo/modules/embeddings/DHOLEmbedding.scala
+++ b/embedding-runtime/src/main/scala/leo/modules/embeddings/DHOLEmbedding.scala
@@ -169,7 +169,7 @@ object DHOLEmbedding extends Embedding {
 
                   val convertedBody = convertFormula(body, variableList.toList++variables)
 
-                  def relativizeVar(connective: THF.BinaryConnective)(v: (String, THF.Type), body: THF.Formula) = v match {
+                  def relativizeVar(connective: THF.BinaryConnective)(v: THF.TypedVariable, body: THF.Formula) = v match {
                     case (str, tp@THF.FunctionTerm(n, _)) =>
                       body
                     case (str, tp) =>
@@ -201,7 +201,7 @@ object DHOLEmbedding extends Embedding {
       * @return simply typed analogue to the argument
       */
     private def convertPi(tp: THF.Type): THF.Type = {
-      def innerConvertPi(variableList: Seq[(String, THF.Type)], ret: THF.Type): THF.Type = variableList match {
+      def innerConvertPi(variableList: Seq[THF.TypedVariable], ret: THF.Type): THF.Type = variableList match {
         case (_, tp)+:shorterList =>
           val body = THF.QuantifiedFormula(THF.!>, shorterList, ret)
           FuncType(tp, innerConvertPi(shorterList, ret))
@@ -382,7 +382,7 @@ object DHOLEmbedding extends Embedding {
         val convertedType = normalizeNestedPi(convertType(typ, variables))
         var declType: THF.Type = convertedType
         val base = atomicTerm(symbol)
-        def typeRelDecls(variableList: Seq[(String, THF.Type)], typetype: THF.Type): List[TPTP.THFAnnotated] = {
+        def typeRelDecls(variableList: Seq[THF.TypedVariable], typetype: THF.Type): List[TPTP.THFAnnotated] = {
           val vars = generatePolyVariables(typetype, variables)
           variables = vars++variables
           val preDeclTp = if (vars == Nil) {

--- a/embedding-runtime/src/main/scala/leo/modules/embeddings/DHOLEmbedding.scala
+++ b/embedding-runtime/src/main/scala/leo/modules/embeddings/DHOLEmbedding.scala
@@ -674,8 +674,9 @@ object DHOLEmbeddingUtils {
    * @param replArgs the terms to substitute for the free variables
    * @return
    */
-  private[embeddings] def substituteVars(body: THF.Formula)(implicit variableList: Seq[(String, THF.Type)], replArgs: Seq[THF.Formula]): THF.Formula = {
-    val varargs = variableList.take(replArgs.length).zip(replArgs)
+  private[embeddings] def substituteVars(body: THF.Formula)(implicit variableList: Seq[THF.TypedVariable], replArgs: Seq[THF.Formula]): (THF.Formula, Seq[THF.TypedVariable]) = {
+    val (newBody,newVarList) = replArgs.foldLeft((body, variableList))(avoidCapture)
+    val varargs = newVarList.take(replArgs.length).zip(replArgs)
     def substituteAtomic(name: String, default: THF.Formula) = {
       varargs.find(_._1._1 == name).map(_._2).getOrElse(default)
     }
@@ -683,14 +684,50 @@ object DHOLEmbeddingUtils {
       case v@THF.Variable(name) => substituteAtomic(name, v)
       case FunctionTerm(f, args) =>
         THFApply(substituteAtomic(f, FunctionTerm(f, Nil)), args.map(substituteSubterm).toList)
-      case THF.QuantifiedFormula(quantifier, variableList, body) => THF.QuantifiedFormula(quantifier, variableList, substituteSubterm(body))
-      case THF.UnaryFormula(connective, body) => THF.UnaryFormula(connective, substituteSubterm(body))
+      case THF.QuantifiedFormula(quantifier, innerList, innerBody) => THF.QuantifiedFormula(quantifier, innerList, substituteSubterm(innerBody))
+      case THF.UnaryFormula(connective, innerBody) => THF.UnaryFormula(connective, substituteSubterm(innerBody))
       case THF.BinaryFormula(connective, left, right) => THF.BinaryFormula(connective, substituteSubterm(left), substituteSubterm(right))
       case THF.Tuple(elements) => THF.Tuple(elements.map(substituteSubterm))
       case THF.ConditionalTerm(condition, thn, els) => THF.ConditionalTerm(substituteSubterm(condition), substituteSubterm(thn), substituteSubterm(els))
       case default => default
     }
-    substituteSubterm(body)
+    return (substituteSubterm(newBody), newVarList)
+  }
+
+  private[embeddings] def avoidCapture(base: (THF.Formula, Seq[(String, THF.Type)]), replacement: THF.Formula): (THF.Formula, Seq[(String, THF.Type)]) = {
+    val foundList = base._2.filter(x => appears(replacement, x._1))
+    val newVarList = foundList.foldLeft(base._2)((tv, oldName) => renameVarInList(tv, oldName._1, oldName._1+"'"))
+    val newBody = foundList.foldLeft(base._1)((f, oldName) => renameVar(f, oldName._1, oldName._1+"'"))
+    return (newBody, newVarList)
+  }
+
+  private[embeddings] def renameVarInList(list: Seq[THF.TypedVariable], oldVarName: String, newVarName: String): Seq[THF.TypedVariable] = list match {
+    case (name, tp)+:shorterList if name == oldVarName => (newVarName, tp)+:(renameVarInList(shorterList, oldVarName, newVarName))
+    case tv+:shorterList => tv+:(renameVarInList(shorterList, oldVarName, newVarName))
+    case Nil => Nil
+  }
+
+  private[embeddings] def renameVar(formula: THF.Formula, oldVarName: String, newVarName: String): THF.Formula = formula match {
+    case THF.BinaryFormula(c, left, right) => THF.BinaryFormula(c, renameVar(left, oldVarName, newVarName), renameVar(right, oldVarName, newVarName))
+    case THF.UnaryFormula(c, f) => THF.UnaryFormula(c, renameVar(f, oldVarName, newVarName))
+    case f@THF.QuantifiedFormula(_, varList, _) if varList.map(_._1).contains(oldVarName) => f
+    case THF.QuantifiedFormula(c, vs, body) => THF.QuantifiedFormula(c, vs, renameVar(body, oldVarName, newVarName))
+    case THF.Variable(name) if name == oldVarName => THF.Variable(newVarName)
+    case THF.Variable(name) => THF.Variable(name)
+    case f@THF.FunctionTerm(_, _) => f
+    case default => throw new EmbeddingException(s"renameVar in unsupportet formula: "+formula.pretty)
+  }
+
+  private[embeddings] def appears(formula: THF.Formula, variableName: String): Boolean = formula match {
+    case THF.BinaryFormula(_, left, right) => appears(left, variableName) | appears(right, variableName)
+    case THF.UnaryFormula(_, f) => appears(f, variableName)
+    case THF.QuantifiedFormula(_, varList, _) if varList.map(_._1).contains(variableName) => false
+    case THF.QuantifiedFormula(_, _, body) => appears(body, variableName)
+    case THF.Variable(name) if name == variableName => true
+    case THF.Variable(_) => false
+    case THF.FunctionTerm(name, _) if name == variableName => true
+    case THF.FunctionTerm(_, _) => false
+    case default => throw new EmbeddingException(s"appears check in unsupportet formula: "+formula.pretty)
   }
 
   /**
@@ -700,15 +737,15 @@ object DHOLEmbeddingUtils {
    * @param constants the constants
    * @return
    */
-  private[embeddings] def inferType(variables: List[(String, TPTP.THF.Type)], constants: List[(String, TPTP.THF.Type)])(formula: TPTP.THF.Formula): TPTP.THF.Formula = {
+  private[embeddings] def inferType(variables: List[THF.TypedVariable], constants: List[(String, TPTP.THF.Type)])(formula: TPTP.THF.Formula): TPTP.THF.Formula = {
     @tailrec
     def applyNTp(tp: THF.Formula, args: Seq[THF.Formula]): THF.Formula = tp match {
       case THF.BinaryFormula(THF.FunTyConstructor, _, codomain) if args.length == 1 => codomain
       case THF.BinaryFormula(THF.FunTyConstructor, _, codomain) => applyNTp(codomain, args.tail)
       case THF.QuantifiedFormula(THF.!>, variableList, body) =>
-        val substBody = substituteVars(body)(variableList, args)
+        val (substBody, newVariableList) = substituteVars(body)(variableList, args)
         if (variableList.length == args.length) { substBody } else {
-          THF.QuantifiedFormula(THF.!>, variableList.drop(args.length), substBody)
+          THF.QuantifiedFormula(THF.!>, newVariableList.drop(args.length), substBody)
         }
     }
     def lookupAtomic(name: String) = (constants++variables).find(_._1 == name)

--- a/embedding-runtime/src/main/scala/leo/modules/embeddings/DHOLTCC.scala
+++ b/embedding-runtime/src/main/scala/leo/modules/embeddings/DHOLTCC.scala
@@ -6,7 +6,7 @@ import TPTP.THF
 import scala.annotation.tailrec
 
 /**
- * @author Daniel Renalter, 2025
+ * @author Rhea Ranalter, 2025/26
  */
 object DHOLTCC extends EmbeddingN {
   import DHOLEmbeddingUtils._
@@ -230,17 +230,15 @@ object DHOLTCC extends EmbeddingN {
             case THF.Eq =>
               if (targetType == bool) {
 //                println("infering left and right of " ++ formula.pretty)//DEBUG
-                val (lSubs, lObligations) = properInferType(variables, constants)(l)
+                val lSubs = properInferType(variables, constants)(l)
                 val lType = lSubs.find(_._1.name == "Alhpa").get 
 //                println("after infer type left: ") //DEBUG
 //                lSubs.map(x => println(x._1.pretty + ":" + x._2.pretty))
-                val (rSubs, rObligations) = properInferType(variables, constants)(r)
+                val rSubs = properInferType(variables, constants)(r)
                 val rType = rSubs.find(_._1.name == "Alhpa").get
 //                println("after infer type right: ")
 //                rSubs.map(x => println(x._1.pretty + ":" + x._2.pretty))
                 genObligation(variables, constants, context)(lType._2, rType._2) ++
-                (rObligations ++ lObligations).flatMap(x => genObligation(variables, constants, context)(x._1, x._2)) ++
-//                (rObligations ++ lObligations).map(x => (genObligation(variables, constants, context)(x._1, x._2))) ++
                 checkType(variables, constants, context)(l, lType._2) ++
                 checkType(variables, constants, context)(r, rType._2)
               }
@@ -318,7 +316,7 @@ object DHOLTCC extends EmbeddingN {
       auxUnApply(formula, Nil)
     }
 
-    private def properInferType(variables: List[(String, THF.Type)], constants: List[(String, THF.Type)])(formula: THF.Formula): (List[(THF.Variable, THF.Type)], List[(THF.Formula, THF.Formula)]) = { 
+    private def properInferType(variables: List[(String, THF.Type)], constants: List[(String, THF.Type)])(formula: THF.Formula): List[(THF.Variable, THF.Type)] = { 
       var varCnt = 0
       def getFreshTypeVar: THF.Type = { //the typos are features and prevent clashes with names in the problem file (:
         varCnt += 1
@@ -387,7 +385,7 @@ object DHOLTCC extends EmbeddingN {
             properInferTypeAux(variables, constants, arguments)(THF.FunctionTerm(n, Seq()), t)
         }
       }
-      solveUnificationProblem(properInferTypeAux(variables, constants, Nil)(formula, THF.Variable("Alhpa")), List[(THF.Variable, THF.Type)](), List[(THF.Formula, THF.Formula)]())
+      solveUnificationProblem(properInferTypeAux(variables, constants, Nil)(formula, THF.Variable("Alhpa")), List[(THF.Variable, THF.Type)]())
     }
 
     private def unsaveApplyFunction(variables: List[THF.TypedVariable], constants: List[(String, THF.Type)], context: List[THF.Formula])(formula: THF.Formula, argument: THF.Formula) = formula match {
@@ -421,7 +419,7 @@ object DHOLTCC extends EmbeddingN {
         throw new EmbeddingException("Can't apply argument " + argument.pretty + " to function " + formula)
     }
 
-    private def solveUnificationProblem(equations: List[THF.Formula], substitutions: List[(THF.Variable, THF.Type)], obligations: List[(THF.Formula, THF.Formula)]): (List[(THF.Variable, THF.Type)], List[(THF.Formula, THF.Formula)]) = { //formula is either function term or variable
+    private def solveUnificationProblem(equations: List[THF.Formula], substitutions: List[(THF.Variable, THF.Type)]): List[(THF.Variable, THF.Type)] = { //formula is either function term or variable
 // DEBUG
 /*
       println("=============================")
@@ -432,51 +430,51 @@ object DHOLTCC extends EmbeddingN {
 //        println("unifying " + equations.head)
         equations.head match {
           case THF.BinaryFormula(_, x, y) if (x == y) =>
-            solveUnificationProblem(equations.tail, substitutions, obligations)
+            solveUnificationProblem(equations.tail, substitutions)
           case THF.BinaryFormula(_, l@THF.BinaryFormula(THF.App, _, _), r@THF.BinaryFormula(THF.App, _, _)) =>
             var (lb, largs) = unApply(l)
             var (rb, rargs) = unApply(r)
             if (lb == rb)
               solveUnificationProblem(equations.tail ++
-                (largs.lazyZip(rargs) map ((x, y) => THF.BinaryFormula(THF.Eq, x, y))), substitutions, obligations)
+                (largs.lazyZip(rargs) map ((x, y) => THF.BinaryFormula(THF.Eq, x, y))), substitutions)
             else
               throw new EmbeddingException("Function missmatch in unification: " + l.pretty + " and " + r.pretty)
           case THF.BinaryFormula(_, THF.QuantifiedFormula(THF.!>, lv+:lvl, lf), THF.QuantifiedFormula(THF.!>, rv+:rvl, rf)) =>
             solveUnificationProblem(equations.tail ++ List(THF.BinaryFormula(THF.Eq, lv._2, rv._2))
               ++ List(THF.BinaryFormula(THF.Eq, THF.QuantifiedFormula(THF.!>, lvl, lf),
-                THF.QuantifiedFormula(THF.!>, rvl, rf))), substitutions, obligations)
+                THF.QuantifiedFormula(THF.!>, rvl, rf))), substitutions)
           case THF.BinaryFormula(_, THF.QuantifiedFormula(THF.!>, lv+:lvl, lf), THF.BinaryFormula(THF.FunTyConstructor, rl, rr)) =>
             solveUnificationProblem(equations.tail ++ List(THF.BinaryFormula(THF.Eq, lv._2, rl))
-              ++ List(THF.BinaryFormula(THF.Eq, THF.QuantifiedFormula(THF.!>, lvl, lf), rr)), substitutions, obligations)
+              ++ List(THF.BinaryFormula(THF.Eq, THF.QuantifiedFormula(THF.!>, lvl, lf), rr)), substitutions)
           case THF.BinaryFormula(_, THF.BinaryFormula(THF.FunTyConstructor, ll, lr), THF.QuantifiedFormula(THF.!>, rv+:rvl, rf)) =>
             solveUnificationProblem(equations.tail ++ List(THF.BinaryFormula(THF.Eq, ll, rv._2))
-              ++ List(THF.BinaryFormula(THF.Eq, lr, THF.QuantifiedFormula(THF.!>, rvl, rf))), substitutions, obligations)
+              ++ List(THF.BinaryFormula(THF.Eq, lr, THF.QuantifiedFormula(THF.!>, rvl, rf))), substitutions)
           case THF.BinaryFormula(_, THF.QuantifiedFormula(THF.!>, Nil, lf), r) =>
-            solveUnificationProblem(equations.tail ++ List(THF.BinaryFormula(THF.Eq, lf, r)), substitutions, obligations)
+            solveUnificationProblem(equations.tail ++ List(THF.BinaryFormula(THF.Eq, lf, r)), substitutions)
           case THF.BinaryFormula(_, l, THF.QuantifiedFormula(THF.!>, Nil, rf)) =>
-            solveUnificationProblem(equations.tail ++ List(THF.BinaryFormula(THF.Eq, l, rf)), substitutions, obligations)
+            solveUnificationProblem(equations.tail ++ List(THF.BinaryFormula(THF.Eq, l, rf)), substitutions)
           case THF.BinaryFormula(_, ol@THF.Variable(l), or@THF.Variable(r)) =>
             val lNr = l.tail.toIntOption
             val rNr = r.tail.toIntOption
             val lgr = if (lNr != None && rNr != None) lNr.get > rNr.get else Ordering.String.gt(l, r)
             val rgl = if (lNr != None && rNr != None) rNr.get > lNr.get else Ordering.String.gt(r, l)
             if (!occurs(or, l) && lgr) {
-              return solveUnificationProblem(equations.tail map (x => variableReplace(x, (l, or))), (ol, or) :: (substitutions.map (x => (x._1, variableReplace(x._2, (l, or))))), obligations)
+              return solveUnificationProblem(equations.tail map (x => variableReplace(x, (l, or))), (ol, or) :: (substitutions.map (x => (x._1, variableReplace(x._2, (l, or))))))
             } else if (!occurs(ol, r) && rgl) {
-              return solveUnificationProblem(equations.tail map (x => variableReplace(x, (r, ol))), (or, ol) :: (substitutions.map (x => (x._1, variableReplace(x._2, (r, ol))))), obligations)
+              return solveUnificationProblem(equations.tail map (x => variableReplace(x, (r, ol))), (or, ol) :: (substitutions.map (x => (x._1, variableReplace(x._2, (r, ol))))))
             } else {
-              return solveUnificationProblem(equations.tail ++ List(equations.head), substitutions, obligations)
+              return solveUnificationProblem(equations.tail ++ List(equations.head), substitutions)
             }
           case THF.BinaryFormula(_, l@THF.Variable(n), r) =>
             if (!occurs(r, n))
-              solveUnificationProblem(equations.tail map (x => variableReplace(x, (n, r))), (l, r) :: (substitutions.map (x => (x._1, variableReplace(x._2, (n, r))))), obligations)
+              solveUnificationProblem(equations.tail map (x => variableReplace(x, (n, r))), (l, r) :: (substitutions.map (x => (x._1, variableReplace(x._2, (n, r))))))
             else
-              solveUnificationProblem(equations.tail ++ List(equations.head), substitutions, obligations)
+              solveUnificationProblem(equations.tail ++ List(equations.head), substitutions)
           case THF.BinaryFormula(_, l, r@(THF.Variable(n))) =>
             if (!occurs(l, n)) {
-              solveUnificationProblem(equations.tail map (x => variableReplace(x, (n, l))), (r, l) :: (substitutions.map (x => (x._1, variableReplace(x._2, (n, l))))), obligations)
+              solveUnificationProblem(equations.tail map (x => variableReplace(x, (n, l))), (r, l) :: (substitutions.map (x => (x._1, variableReplace(x._2, (n, l))))))
             } else {
-              solveUnificationProblem(equations.tail ++ List(equations.head), substitutions, obligations)
+              solveUnificationProblem(equations.tail ++ List(equations.head), substitutions)
             }
           case THF.BinaryFormula(THF.Eq, l, r) =>
             throw new TypeErrorException(l,r)  
@@ -484,7 +482,7 @@ object DHOLTCC extends EmbeddingN {
             throw new EmbeddingException("Non-Equality handed to unification problem: " + x.pretty)
         }
       } else {
-        return (substitutions, obligations)
+        return substitutions
       }
     }
 

--- a/embedding-runtime/src/main/scala/leo/modules/embeddings/DHOLTCC.scala
+++ b/embedding-runtime/src/main/scala/leo/modules/embeddings/DHOLTCC.scala
@@ -147,7 +147,7 @@ object DHOLTCC extends EmbeddingN {
         case _ => Nil
       }
       // DEBUG
-      /*
+/*
       println("-----------------")
       println("using variables: ")
       variables map (x => println(" - " + x._1 + ":" + x._2.pretty))
@@ -155,8 +155,8 @@ object DHOLTCC extends EmbeddingN {
       constants map (x => println(" - " + x._1 + ":" + x._2.pretty))
       println("using context: ")
       context map (x => println(" - " + x.pretty))
-       println("checking if: " + formula.pretty + " is of type " + targetType.pretty)
-       */
+      println("checking if: " + formula.pretty + " is of type " + targetType.pretty)
+ */
       formula match {
         case THF.UnaryFormula(_, f) => 
           if (targetType == bool)
@@ -175,28 +175,21 @@ object DHOLTCC extends EmbeddingN {
                   throw new EmbeddingException("Error in typing the simple skeleton:"+f.pretty)
               case THF.!> =>
                 if (targetType == univTp) {
-                  if (vl.isEmpty)
-                    checkType(variables, constants, context)(f, targetType)
-                  else {
-                    val curVar = vl.head
-                    checkType(variables, constants, context)(curVar._2, targetType) ++
-                    checkType(variables++List(curVar), constants, context)(THF.QuantifiedFormula(q, vl.tail, f), targetType)
-                  }
+                  val curVar = vl.head
+                  checkType(variables, constants, context)(curVar._2, targetType) ++ //This checks that the type of the type of the term arguments is type
+                  checkType(variables++List(curVar), constants, context)(THF.QuantifiedFormula(q, vl.tail, f), targetType)
+
                 }
                 else
                   throw new EmbeddingException("No type-hirarchy. " + formula.pretty + " must be of type " + univTp.pretty + " is of type " + targetType.pretty + ".")
               case THF.^ =>
-                if (vl.isEmpty)                                                                                  //catch empty quantifier list due to processing
-                  checkType(variables, constants, context)(f, targetType)
-                else {
-                  val curVar = vl.head
-                  targetType match {
-                    case THF.QuantifiedFormula(THF.!>, (curType@(n, curVar._2)) :: ivl, b) =>
-                      checkType(variables++List(curVar)++List(curType), constants, context)(THF.QuantifiedFormula(q, vl.tail, f) , THF.QuantifiedFormula(THF.!>, ivl, b))
-                    case THF.BinaryFormula(THF.FunTyConstructor, curVar._2, b) =>
-                      checkType(variables++List(curVar), constants, context)(THF.QuantifiedFormula(q, vl.tail, f), b)
-                    case b => throw new EmbeddingException("Error in typing the simple skeleton:"+f.pretty+ " needs to have a function type, but is of type " + b.pretty)
-                  }
+                val curVar = vl.head
+                targetType match {
+                  case THF.QuantifiedFormula(THF.!>, (curType@(n, curVar._2)) :: ivl, b) =>
+                    checkType(variables++List(curVar)++List(curType), constants, context)(THF.QuantifiedFormula(q, vl.tail, f), THF.QuantifiedFormula(THF.!>, ivl, b))
+                  case THF.BinaryFormula(THF.FunTyConstructor, curVar._2, b) =>
+                    checkType(variables++List(curVar), constants, context)(THF.QuantifiedFormula(q, vl.tail, f), b)
+                  case b => throw new EmbeddingException("Error in typing the simple skeleton:"+f.pretty+ " needs to have a function type, but is of type " + b.pretty)
                 }
               case _ =>
                 throw new EmbeddingException("Unsupported quantifier:"+q)                                        //other quantifiers (SumTypeConst, ProdTypeConst, Choice, Selection) not supported
@@ -223,9 +216,11 @@ object DHOLTCC extends EmbeddingN {
                   case t =>
                     throw new EmbeddingException("Unexpected type: " + t.pretty + " for term " + base.pretty)
                 }
-//              args map (x => println(x.pretty))
-//              println(" for basetypeargs \n")
-//              instanciatedBaseTypeArgs map (x => println(x.pretty))
+              /*
+              args map (x => println(x.pretty))
+               println(" for basetypeargs")
+               instanciatedBaseTypeArgs map (x => println(x.pretty))
+               */
               if (args.length == instanciatedBaseTypeArgs.length) {
                 genObligation(variables, constants, context)(inferType(variables, constants)(f), targetType) ++
                 (args.lazyZip(instanciatedBaseTypeArgs) flatMap ((x,y) => checkType(variables, constants, context)(x,y)))
@@ -234,17 +229,20 @@ object DHOLTCC extends EmbeddingN {
               }
             case THF.Eq =>
               if (targetType == bool) {
-                val lSubs = (properInferType(variables, constants)(l))
+//                println("infering left and right of " ++ formula.pretty)//DEBUG
+                val (lSubs, lObligations) = properInferType(variables, constants)(l)
                 val lType = lSubs.find(_._1.name == "Alhpa").get 
-//                println("after infer type left: ")
+//                println("after infer type left: ") //DEBUG
 //                lSubs.map(x => println(x._1.pretty + ":" + x._2.pretty))
-                val rSubs = (properInferType(variables, constants)(r))
+                val (rSubs, rObligations) = properInferType(variables, constants)(r)
                 val rType = rSubs.find(_._1.name == "Alhpa").get
 //                println("after infer type right: ")
 //                rSubs.map(x => println(x._1.pretty + ":" + x._2.pretty))
                 genObligation(variables, constants, context)(lType._2, rType._2) ++
-                  checkType(variables, constants, context)(l, lType._2) ++
-                  checkType(variables, constants, context)(r, rType._2)
+                (rObligations ++ lObligations).flatMap(x => genObligation(variables, constants, context)(x._1, x._2)) ++
+//                (rObligations ++ lObligations).map(x => (genObligation(variables, constants, context)(x._1, x._2))) ++
+                checkType(variables, constants, context)(l, lType._2) ++
+                checkType(variables, constants, context)(r, rType._2)
               }
               else
                 throw new EmbeddingException("Error in typing the simple skeleton: Equality "+f.pretty+" needs to be of type bool")
@@ -261,11 +259,8 @@ object DHOLTCC extends EmbeddingN {
               else
                 throw new EmbeddingException("No type-hirarchy. " + formula.pretty + " must be of type " + univTp.pretty + " is of type " + targetType.pretty + ".")
             case THF.Impl | THF.& | THF.~& =>
-              if (targetType == bool) {
-                val usedVars = variables.filter(x => occurs(l, x._1))
-                val conj = l
-                checkType(variables, constants, context)(l, targetType) ++ checkType(variables, constants, (conj::context))(r, targetType)
-              }
+              if (targetType == bool) 
+                checkType(variables, constants, context)(l, targetType) ++ checkType(variables, constants, (l::context))(r, targetType)
               else
                 throw new EmbeddingException("Error in typing the simple skeleton: Boolean "+f.pretty+" needs to be of type bool")
             case THF.<= =>
@@ -274,11 +269,8 @@ object DHOLTCC extends EmbeddingN {
               else
                 throw new EmbeddingException("Error in typing the simple skeleton: Boolean "+f.pretty+" needs to be of type bool")
             case THF.| | THF.~| =>
-              if (targetType == bool) {
-                val usedVars = variables.filter(x => occurs(l, x._1))
-                val conj = l
-                checkType(variables, constants, context)(l, targetType) ++ checkType(variables, constants, (THF.UnaryFormula(THF.~, conj))::context)(r, targetType)
-              }
+              if (targetType == bool)
+                checkType(variables, constants, context)(l, targetType) ++ checkType(variables, constants, (THF.UnaryFormula(THF.~, l))::context)(r, targetType)
               else
                 throw new EmbeddingException("Error in typing the simple skeleton: Boolean "+f.pretty+" needs to be of type bool")
             case c =>
@@ -326,7 +318,7 @@ object DHOLTCC extends EmbeddingN {
       auxUnApply(formula, Nil)
     }
 
-    private def properInferType(variables: List[(String, THF.Type)], constants: List[(String, THF.Type)])(formula: THF.Formula): List[(THF.Variable, THF.Type)] = { 
+    private def properInferType(variables: List[(String, THF.Type)], constants: List[(String, THF.Type)])(formula: THF.Formula): (List[(THF.Variable, THF.Type)], List[(THF.Formula, THF.Formula)]) = { 
       var varCnt = 0
       def getFreshTypeVar: THF.Type = { //the typos are features and prevent clashes with names in the problem file (:
         varCnt += 1
@@ -345,14 +337,14 @@ object DHOLTCC extends EmbeddingN {
             if (foundVal != None){
               var ret = foundVal.get._2
               if (arguments != Nil)
-                ret = arguments.foldLeft(foundVal.get._2)((acc, v) => applyFunction(variables, constants, Nil)(acc, v))
+                ret = arguments.foldLeft(foundVal.get._2)((acc, v) => unsaveApplyFunction(variables, constants, Nil)(acc, v))
 //              println(" and found: " + ret + ", assigned to " + t)
               List(THF.BinaryFormula(THF.Eq, uniquifyVarNamesAux(ret), t))
             }
             else
               throw new EmbeddingException("Failed to find variable or constant during type inference: " + f.pretty + " : " + t.pretty)
           case THF.BinaryFormula(THF.App, l, r) =>
-            val rType = properInferType(variables, constants)(r).find(_._1.name == "Alhpa").get._2
+            val rType = inferType(variables, constants)(r)//properInferType(variables, constants)(r)._1.find(_._1.name == "Alhpa").get._2 this should be enough
 //            println("rType = " + rType)
             if (rType == univTp) {
               properInferTypeAux(variables, constants, arguments++List(r))(l, t)
@@ -395,7 +387,18 @@ object DHOLTCC extends EmbeddingN {
             properInferTypeAux(variables, constants, arguments)(THF.FunctionTerm(n, Seq()), t)
         }
       }
-      solveUnificationProblem(properInferTypeAux(variables, constants, Nil)(formula, THF.Variable("Alhpa")), List[(THF.Variable, THF.Type)]())
+      solveUnificationProblem(properInferTypeAux(variables, constants, Nil)(formula, THF.Variable("Alhpa")), List[(THF.Variable, THF.Type)](), List[(THF.Formula, THF.Formula)]())
+    }
+
+    private def unsaveApplyFunction(variables: List[THF.TypedVariable], constants: List[(String, THF.Type)], context: List[THF.Formula])(formula: THF.Formula, argument: THF.Formula) = formula match {
+      case THF.QuantifiedFormula(THF.!>, v+:Nil, f) =>
+        variableReplace(f, (v._1, argument))
+      case THF.QuantifiedFormula(THF.!>, v+:vl, f) =>
+        THF.QuantifiedFormula(THF.!>, vl, variableReplace(f, (v._1, argument)))
+      case THF.BinaryFormula(THF.FunTyConstructor, l, r) =>
+        r
+      case _ =>
+        throw new EmbeddingException("Can't unsavely apply argument " + argument.pretty + " to function " + formula)
     }
 
     private def applyFunction(variables: List[(String, THF.Type)], constants: List[(String, THF.Type)], context: List[THF.Formula])(formula: THF.Formula, argument: THF.Formula) = formula match {
@@ -418,66 +421,70 @@ object DHOLTCC extends EmbeddingN {
         throw new EmbeddingException("Can't apply argument " + argument.pretty + " to function " + formula)
     }
 
-    private def solveUnificationProblem(equations: List[THF.Formula], substitutions: List[(THF.Variable, THF.Type)]): List[(THF.Variable, THF.Type)] = { //formula is either function term or variable
+    private def solveUnificationProblem(equations: List[THF.Formula], substitutions: List[(THF.Variable, THF.Type)], obligations: List[(THF.Formula, THF.Formula)]): (List[(THF.Variable, THF.Type)], List[(THF.Formula, THF.Formula)]) = { //formula is either function term or variable
 // DEBUG
-//      println("=============================")
-//      equations map (x => println(x.pretty))
-//      println("=============================")
+/*
+      println("=============================")
+      equations map (x => println(x.pretty))
+       println("=============================")
+ */
       if(!equations.isEmpty) {
 //        println("unifying " + equations.head)
         equations.head match {
           case THF.BinaryFormula(_, x, y) if (x == y) =>
-            solveUnificationProblem(equations.tail, substitutions)
+            solveUnificationProblem(equations.tail, substitutions, obligations)
           case THF.BinaryFormula(_, l@THF.BinaryFormula(THF.App, _, _), r@THF.BinaryFormula(THF.App, _, _)) =>
             var (lb, largs) = unApply(l)
             var (rb, rargs) = unApply(r)
             if (lb == rb)
               solveUnificationProblem(equations.tail ++
-                (largs.lazyZip(rargs) map ((x, y) => THF.BinaryFormula(THF.Eq, x, y))), substitutions)
+                (largs.lazyZip(rargs) map ((x, y) => THF.BinaryFormula(THF.Eq, x, y))), substitutions, obligations)
             else
               throw new EmbeddingException("Function missmatch in unification: " + l.pretty + " and " + r.pretty)
           case THF.BinaryFormula(_, THF.QuantifiedFormula(THF.!>, lv+:lvl, lf), THF.QuantifiedFormula(THF.!>, rv+:rvl, rf)) =>
             solveUnificationProblem(equations.tail ++ List(THF.BinaryFormula(THF.Eq, lv._2, rv._2))
               ++ List(THF.BinaryFormula(THF.Eq, THF.QuantifiedFormula(THF.!>, lvl, lf),
-                THF.QuantifiedFormula(THF.!>, rvl, rf))), substitutions)
+                THF.QuantifiedFormula(THF.!>, rvl, rf))), substitutions, obligations)
           case THF.BinaryFormula(_, THF.QuantifiedFormula(THF.!>, lv+:lvl, lf), THF.BinaryFormula(THF.FunTyConstructor, rl, rr)) =>
             solveUnificationProblem(equations.tail ++ List(THF.BinaryFormula(THF.Eq, lv._2, rl))
-              ++ List(THF.BinaryFormula(THF.Eq, THF.QuantifiedFormula(THF.!>, lvl, lf), rr)), substitutions)
+              ++ List(THF.BinaryFormula(THF.Eq, THF.QuantifiedFormula(THF.!>, lvl, lf), rr)), substitutions, obligations)
           case THF.BinaryFormula(_, THF.BinaryFormula(THF.FunTyConstructor, ll, lr), THF.QuantifiedFormula(THF.!>, rv+:rvl, rf)) =>
             solveUnificationProblem(equations.tail ++ List(THF.BinaryFormula(THF.Eq, ll, rv._2))
-              ++ List(THF.BinaryFormula(THF.Eq, lr, THF.QuantifiedFormula(THF.!>, rvl, rf))), substitutions)
+              ++ List(THF.BinaryFormula(THF.Eq, lr, THF.QuantifiedFormula(THF.!>, rvl, rf))), substitutions, obligations)
           case THF.BinaryFormula(_, THF.QuantifiedFormula(THF.!>, Nil, lf), r) =>
-            solveUnificationProblem(equations.tail ++ List(THF.BinaryFormula(THF.Eq, lf, r)), substitutions)
+            solveUnificationProblem(equations.tail ++ List(THF.BinaryFormula(THF.Eq, lf, r)), substitutions, obligations)
           case THF.BinaryFormula(_, l, THF.QuantifiedFormula(THF.!>, Nil, rf)) =>
-            solveUnificationProblem(equations.tail ++ List(THF.BinaryFormula(THF.Eq, l, rf)), substitutions)
+            solveUnificationProblem(equations.tail ++ List(THF.BinaryFormula(THF.Eq, l, rf)), substitutions, obligations)
           case THF.BinaryFormula(_, ol@THF.Variable(l), or@THF.Variable(r)) =>
             val lNr = l.tail.toIntOption
             val rNr = r.tail.toIntOption
             val lgr = if (lNr != None && rNr != None) lNr.get > rNr.get else Ordering.String.gt(l, r)
             val rgl = if (lNr != None && rNr != None) rNr.get > lNr.get else Ordering.String.gt(r, l)
             if (!occurs(or, l) && lgr) {
-              return solveUnificationProblem(equations.tail map (x => variableReplace(x, (l, or))), (ol, or) :: (substitutions.map (x => (x._1, variableReplace(x._2, (l, or))))))
+              return solveUnificationProblem(equations.tail map (x => variableReplace(x, (l, or))), (ol, or) :: (substitutions.map (x => (x._1, variableReplace(x._2, (l, or))))), obligations)
             } else if (!occurs(ol, r) && rgl) {
-              return solveUnificationProblem(equations.tail map (x => variableReplace(x, (r, ol))), (or, ol) :: (substitutions.map (x => (x._1, variableReplace(x._2, (r, ol))))))
+              return solveUnificationProblem(equations.tail map (x => variableReplace(x, (r, ol))), (or, ol) :: (substitutions.map (x => (x._1, variableReplace(x._2, (r, ol))))), obligations)
             } else {
-              return solveUnificationProblem(equations.tail ++ List(equations.head), substitutions)
+              return solveUnificationProblem(equations.tail ++ List(equations.head), substitutions, obligations)
             }
           case THF.BinaryFormula(_, l@THF.Variable(n), r) =>
             if (!occurs(r, n))
-              solveUnificationProblem(equations.tail map (x => variableReplace(x, (n, r))), (l, r) :: (substitutions.map (x => (x._1, variableReplace(x._2, (n, r))))))
+              solveUnificationProblem(equations.tail map (x => variableReplace(x, (n, r))), (l, r) :: (substitutions.map (x => (x._1, variableReplace(x._2, (n, r))))), obligations)
             else
-              solveUnificationProblem(equations.tail ++ List(equations.head), substitutions)
+              solveUnificationProblem(equations.tail ++ List(equations.head), substitutions, obligations)
           case THF.BinaryFormula(_, l, r@(THF.Variable(n))) =>
             if (!occurs(l, n)) {
-              solveUnificationProblem(equations.tail map (x => variableReplace(x, (n, l))), (r, l) :: (substitutions.map (x => (x._1, variableReplace(x._2, (n, l))))))
+              solveUnificationProblem(equations.tail map (x => variableReplace(x, (n, l))), (r, l) :: (substitutions.map (x => (x._1, variableReplace(x._2, (n, l))))), obligations)
             } else {
-              solveUnificationProblem(equations.tail ++ List(equations.head), substitutions)
+              solveUnificationProblem(equations.tail ++ List(equations.head), substitutions, obligations)
             }
+          case THF.BinaryFormula(THF.Eq, l, r) =>
+            throw new TypeErrorException(l,r)  
           case x =>
-            throw new EmbeddingException("Non-Equality handed to unification problem: " + x)
+            throw new EmbeddingException("Non-Equality handed to unification problem: " + x.pretty)
         }
       } else {
-        return substitutions
+        return (substitutions, obligations)
       }
     }
 
@@ -551,55 +558,6 @@ object DHOLTCC extends EmbeddingN {
             f
         case _ =>
           throw new EmbeddingException("Unsupported formula to replace in: " + formula)
-      }
-    }
-
-    /**
-      * Infer the type of the given term from the types of the constants and variables in scope
-      * @param formula the term whoose type to infer
-      * @param variables the variables in the scope of the term
-      * @param constants the constants
-      * @return
-      */
-    private def inferType(variables: List[(String, TPTP.THF.Type)], constants: List[(String, TPTP.THF.Type)])(formula: TPTP.THF.Formula): TPTP.THF.Formula = {
-      @tailrec
-      def applyNTp(tp: THF.Formula, args: Seq[THF.Formula]): THF.Formula = tp match {
-        case THF.BinaryFormula(THF.FunTyConstructor, _, codomain) if args.length == 1 => codomain
-        case THF.BinaryFormula(THF.FunTyConstructor, _, codomain) => applyNTp(codomain, args.tail)
-        case THF.QuantifiedFormula(THF.!>, variableList, body) =>
-          val substBody = substituteVars(body)(variableList, args)
-          if (variableList.length == args.length) { substBody } else {
-            THF.QuantifiedFormula(THF.!>, variableList.drop(args.length), substBody)
-          }
-      }
-
-      def lookupAtomic(name: String) = (constants++variables).find(_._1 == name)
-        .getOrElse(throw new EmbeddingException(s"Failed to look up variable or constant: "+name))._2
-      def unsupportedFormula(): THF.Formula = throw new EmbeddingException(s"Not allowed on term level: "+formula.pretty)
-      formula match {
-        case THF.FunctionTerm(f, Nil) => lookupAtomic(f)
-        case THF.FunctionTerm(f, args) =>
-          applyNTp(inferType(variables, constants)(atomicTerm(f)), args)
-        case THF.QuantifiedFormula(quantifier, variableList, body) => quantifier match {
-          case THF.! | THF.? => bool
-          case THF.^ => THF.QuantifiedFormula(THF.!>, variableList, inferType(variables, constants)(body))
-          case default => throw new EmbeddingException(s"Unsupported on type level: "+default.pretty)
-        }
-        case THF.Variable(name) => lookupAtomic(name)
-        case THF.UnaryFormula(THF.~, _) => bool
-        case THF.BinaryFormula(connective, left, right) => connective match {
-          case THF.App => applyNTp(inferType(variables, constants)(left), Seq(right))
-          case THF.FunTyConstructor | THF.ProductTyConstructor | THF.SumTyConstructor =>
-            throw new EmbeddingException(s"Not allowed on term level: "+connective.pretty)
-          case _ => bool
-        }
-        case THF.Tuple(_) => unsupportedFormula()
-        case THF.ConditionalTerm(_, thn, _) => inferType(variables, constants)(thn)
-        case THF.LetTerm(_, _, _) => unsupportedFormula()
-        case THF.DefinedTH1ConstantTerm(_) => unsupportedFormula()
-        case THF.ConnectiveTerm(_) => unsupportedFormula()
-        case THF.DistinctObject(_) => unsupportedFormula()
-        case THF.NumberTerm(_) => unsupportedFormula()
       }
     }
     private def uniquifyVarNamesAux(formula: THF.Formula): THF.Formula = formula match {

--- a/embedding-runtime/src/main/scala/leo/modules/embeddings/DHOLTCC.scala
+++ b/embedding-runtime/src/main/scala/leo/modules/embeddings/DHOLTCC.scala
@@ -85,11 +85,11 @@ object DHOLTCC extends EmbeddingN {
 
       val constants = typeFormulas map {case TPTP.THFAnnotated(_, _, THF.Typing(n, t), _) => (n, t)}
 //      println("in typecheck conjecture") //DEBUG
-      val obligations = checkType(List[(String, THF.Type)](), constants.toList, List[THF.Formula]())(conjecture, bool).filter(x => x.exists(y => y.role == "conjecture"))
+      val obligations = checkType(List[THF.TypedVariable](), constants.toList, List[THF.Formula]())(conjecture, bool).filter(x => x.exists(y => y.role == "conjecture"))
       obligations.map(x => TPTP.Problem(problem.includes, contextFormulas.toList ++ x, Map.empty))
     }
 
-    private def genObligationFormula(variables: List[(String, THF.Type)], constants: List[(String, THF.Type)], context: List[THF.Formula])(a: THF.Type, b:THF.Type): List[TPTP.THFAnnotated] = {
+    private def genObligationFormula(variables: List[THF.TypedVariable], constants: List[(String, THF.Type)], context: List[THF.Formula])(a: THF.Type, b:THF.Type): List[TPTP.THFAnnotated] = {
       val conj:THF.Formula = THF.BinaryFormula(THF.Eq, a, b)
       val usedVars = (context++List(conj)).flatMap(y => (variables.filter(x => occurs(y, x._1)))).distinct
       var witnesses = usedVars
@@ -112,7 +112,7 @@ object DHOLTCC extends EmbeddingN {
       return newFormulas
     }
 
-    private def genObligation(variables: List[(String, THF.Type)], constants: List[(String, THF.Type)], context: List[THF.Formula])(a: THF.Type, b:THF.Type): List[List[TPTP.THFAnnotated]] = (a, b) match {
+    private def genObligation(variables: List[THF.TypedVariable], constants: List[(String, THF.Type)], context: List[THF.Formula])(a: THF.Type, b:THF.Type): List[List[TPTP.THFAnnotated]] = (a, b) match {
       case (a, b) if (a == b) => Nil
       case (THF.QuantifiedFormula(THF.!>, ahead::avl, af), THF.QuantifiedFormula(THF.!>, bhead::bvl, bf)) =>
         genObligation(variables, constants, context)(ahead._2, bhead._2) ++
@@ -138,7 +138,7 @@ object DHOLTCC extends EmbeddingN {
     }
 
     //Check simply typed skeleton
-    private def checkType(variables: List[(String, THF.Type)], constants: List[(String, THF.Type)], context: List[THF.Formula])(formula: THF.Formula, targetType: THF.Type): List[List[TPTP.THFAnnotated]] = {
+    private def checkType(variables: List[THF.TypedVariable], constants: List[(String, THF.Type)], context: List[THF.Formula])(formula: THF.Formula, targetType: THF.Type): List[List[TPTP.THFAnnotated]] = {
       def getArgTypes(formula: THF.Formula): List[THF.Type] = formula match {
         case THF.BinaryFormula(THF.FunTyConstructor, a, b) => a :: getArgTypes(b)
         case THF.QuantifiedFormula(THF.!>, Nil, f) => getArgTypes(f)
@@ -316,7 +316,7 @@ object DHOLTCC extends EmbeddingN {
       auxUnApply(formula, Nil)
     }
 
-    private def properInferType(variables: List[(String, THF.Type)], constants: List[(String, THF.Type)])(formula: THF.Formula): List[(THF.Variable, THF.Type)] = { 
+    private def properInferType(variables: List[THF.TypedVariable], constants: List[(String, THF.Type)])(formula: THF.Formula): List[(THF.Variable, THF.Type)] = { 
       var varCnt = 0
       def getFreshTypeVar: THF.Type = { //the typos are features and prevent clashes with names in the problem file (:
         varCnt += 1
@@ -326,7 +326,7 @@ object DHOLTCC extends EmbeddingN {
         varCnt += 1
         "FreshIntorducedVarName"+(varCnt-1)
       }
-      def properInferTypeAux(variables: List[(String, THF.Type)], constants: List[(String, THF.Type)], arguments: List[THF.Formula])(f: THF.Formula, t: THF.Type): List[THF.BinaryFormula] = {
+      def properInferTypeAux(variables: List[THF.TypedVariable], constants: List[(String, THF.Type)], arguments: List[THF.Formula])(f: THF.Formula, t: THF.Type): List[THF.BinaryFormula] = {
 //        println("infering type of: " + f.pretty + "( " + f + " )")
         f match {
           case THF.FunctionTerm(n, _) =>
@@ -399,7 +399,7 @@ object DHOLTCC extends EmbeddingN {
         throw new EmbeddingException("Can't unsavely apply argument " + argument.pretty + " to function " + formula)
     }
 
-    private def applyFunction(variables: List[(String, THF.Type)], constants: List[(String, THF.Type)], context: List[THF.Formula])(formula: THF.Formula, argument: THF.Formula) = formula match {
+    private def applyFunction(variables: List[THF.TypedVariable], constants: List[(String, THF.Type)], context: List[THF.Formula])(formula: THF.Formula, argument: THF.Formula) = formula match {
       case THF.QuantifiedFormula(THF.!>, v+:Nil, f) =>
         if(checkType(variables, constants, context)(argument, v._2) == Nil) //pretty inefficient, maybe reconsider
           variableReplace(f, (v._1, argument))

--- a/embedding-runtime/src/main/scala/leo/modules/embeddings/package.scala
+++ b/embedding-runtime/src/main/scala/leo/modules/embeddings/package.scala
@@ -14,7 +14,9 @@ package object embeddings {
   /** Exception is thrown if the input problem lies outside the scope of an embedding (i.e. due to unsupported
    * language features). */
   final class UnsupportedFragmentException(msg: String) extends RuntimeException(msg)
-
+  /** Exception is thrown due to inability to unify terms, which happens during type inference for equality
+   * in DHOL type-checking. */
+  final class TypeErrorException(val left: THF.Formula, val right: THF.Formula) extends RuntimeException
 
   /////////////////////////////////////////////////////////////////////////////////////
   /////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Fixed a bug in DHOLEmbedding where variables were not replaced in a capture avoiding way.
- DHOLTCC type-inference now throws a new exception resulting in SZS Status TypeError instead of a generic EmbeddingException in cases where it's clear that the issue stems from a error in the types of the problem.
- Minor clean-up in DHOLEmbedding and DHOLTCC.